### PR TITLE
Allow `link` in metadata to override post URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ Metalsmith('example')
   }))
 ```
 
+### Item metadata
+
+Items get their `url` field from the file's path by default. To direct links elsewhere, you can override the URL by providing a `link` metadata entry for a file:
+
+```
+---
+link: http://example.com
+---
+This post is an external link.
+```
+
 ## Options & their defaults
 
 ```es6

--- a/index.js
+++ b/index.js
@@ -47,9 +47,17 @@ module.exports = (options = {}) => {
     Object.assign(feed, settings.json)
 
     collection.forEach((file) => {
+      // The item's URL either comes from its path or an explicit link.
+      let url
+      if (file.link) {
+        url = file.link
+      } else if (metadata.site && metadata.site.url) {
+        url = `${metadata.site.url}${file.path}`
+      }
+
       feed.items.push({
         id: file.path,
-        url: metadata.site && metadata.site.url ? `${metadata.site.url}${file.path}` : undefined,
+        url: url,
         title: file.title,
         content_html: file.contents.toString('utf8'),
         date_published: file.date


### PR DESCRIPTION
This feature is inspired by https://github.com/hurrymaplelad/metalsmith-feed/pull/21, which lets individual items override their link in the feed by specifying a `link` metadata field. That enables posts like on Daring Fireball, for example, where "opening" a feed item takes you directly to the external URL.